### PR TITLE
[BUGFIX] sonarcloud: Shallow clone detected during the analysis. Some…

### DIFF
--- a/.github/workflows/node-coverage.js.yml
+++ b/.github/workflows/node-coverage.js.yml
@@ -22,7 +22,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
-
+      with:
+        fetch-depth: 0
     - name: Set up Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:


### PR DESCRIPTION
… files will miss SCM information. This will affect features like auto-assignment of issues. Please configure your build to disable shallow clone.

https://stackoverflow.com/questions/59000099/sonarqube-with-shallow-clone-warning-even-with-shallow-disabled-on-jenkins-build