### PR TITLE
[CONFIG] [Github Actions] sonarcloud deprecation replacement. https:/…

### DIFF
--- a/.github/workflows/node-coverage.js.yml
+++ b/.github/workflows/node-coverage.js.yml
@@ -37,8 +37,8 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }} # required
           verbose: true # optional (default = false)
 
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
+      - name: Analyze with SonarQube / SonarCloud
+        uses: SonarSource/sonarqube-scan-action@master
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           # Needed to get PR information, if any


### PR DESCRIPTION
…/github.com/SonarSource/sonarqube-scan-action

Warning

This action is deprecated and will be removed in a future release. Please use the sonarqube-scan-action action instead. The sonarqube-scan-action is a drop-in replacement for this action.