### PR TITLE
[BUGFIX] SonarQube: Prefer `Number.parseInt` over `parseInt`.

### DIFF
--- a/src/hackerrank/implementation/countApplesAndOranges.ts
+++ b/src/hackerrank/implementation/countApplesAndOranges.ts
@@ -25,9 +25,7 @@ function countApplesAndOranges(
     }
   }
 
-  const result: number[] = [];
-  result.push(cApples);
-  result.push(cOranges);
+  const result: number[] = [cApples, cOranges];
 
   return result.join('\n');
 }

--- a/src/hackerrank/implementation/countingValleys.ts
+++ b/src/hackerrank/implementation/countingValleys.ts
@@ -11,7 +11,7 @@ function countingValleys(steps: number, path: string): number {
 
   console.debug(stepList);
 
-  stepList.forEach((step) => {
+  for (const step of stepList) {
     if (step === 'D') {
       if (altitude === 0) {
         valleys += 1;
@@ -21,7 +21,7 @@ function countingValleys(steps: number, path: string): number {
     if (step === 'U') {
       altitude += 1;
     }
-  });
+  }
 
   return valleys;
 }

--- a/src/hackerrank/implementation/repeatedString.ts
+++ b/src/hackerrank/implementation/repeatedString.ts
@@ -9,11 +9,11 @@ function countAs(word: string): number {
 
   const chars = word.split('');
 
-  chars.forEach((char) => {
+  for (const char of chars) {
     if (char === 'a') {
       result += 1;
     }
-  });
+  }
 
   return result;
 }

--- a/src/hackerrank/implementation/sockMerchant.ts
+++ b/src/hackerrank/implementation/sockMerchant.ts
@@ -11,9 +11,9 @@ function sockMerchant(n: number, ar: number[]): number {
 
   const matches: Matches = {};
 
-  ar.forEach((v) => {
+  for (const v of ar) {
     matches[v] = matches?.[v] ? matches[v] + 1 : 1;
-  });
+  }
 
   console.debug(matches);
 

--- a/src/hackerrank/interview_preparation_kit/arrays/2d_array.test.ts
+++ b/src/hackerrank/interview_preparation_kit/arrays/2d_array.test.ts
@@ -8,7 +8,7 @@ describe('arrays: 2d Array hourglassSum', () => {
   it('hourglassSum Test Cases', () => {
     expect.assertions(4);
 
-    TEST_CASES.forEach((test) => {
+    for (const test of TEST_CASES) {
       const answer = hourglassSum(test.input);
 
       console.debug(
@@ -16,7 +16,7 @@ describe('arrays: 2d Array hourglassSum', () => {
       );
 
       expect(answer).toStrictEqual(test.expected);
-    });
+    }
 
     expect(TEST_CASES).toHaveLength(3);
   });

--- a/src/hackerrank/interview_preparation_kit/arrays/2d_array.ts
+++ b/src/hackerrank/interview_preparation_kit/arrays/2d_array.ts
@@ -7,18 +7,19 @@ function gethourGlass(
   positionX: number,
   positionY: number
 ): number[] {
-  const result: number[] = [];
+  const result: number[] = [
+    // top
+    arr[positionX - 1][positionY - 1],
+    arr[positionX - 1][positionY],
+    arr[positionX - 1][positionY + 1],
+    // middle
+    arr[positionX][positionY],
+    // bottom
+    arr[positionX + 1][positionY - 1],
+    arr[positionX + 1][positionY],
+    arr[positionX + 1][positionY + 1]
+  ];
 
-  // top
-  result.push(arr[positionX - 1][positionY - 1]);
-  result.push(arr[positionX - 1][positionY]);
-  result.push(arr[positionX - 1][positionY + 1]);
-  // middle
-  result.push(arr[positionX][positionY]);
-  // bottom
-  result.push(arr[positionX + 1][positionY - 1]);
-  result.push(arr[positionX + 1][positionY]);
-  result.push(arr[positionX + 1][positionY + 1]);
   return result;
 }
 

--- a/src/hackerrank/interview_preparation_kit/arrays/cruch_bruteforce.test.ts
+++ b/src/hackerrank/interview_preparation_kit/arrays/cruch_bruteforce.test.ts
@@ -9,7 +9,7 @@ describe('arrays: crush (bruteforce) small cases', () => {
   it('arrayManipulation Test Cases', () => {
     expect.assertions(4);
 
-    TEST_CASES.forEach((test) => {
+    for (const test of TEST_CASES) {
       const answer = arrayManipulation(test.n, test.queries);
 
       console.debug(
@@ -17,7 +17,7 @@ describe('arrays: crush (bruteforce) small cases', () => {
       );
 
       expect(answer).toStrictEqual(test.expected);
-    });
+    }
 
     expect(TEST_CASES).toHaveLength(3);
   });

--- a/src/hackerrank/interview_preparation_kit/arrays/cruch_bruteforce.ts
+++ b/src/hackerrank/interview_preparation_kit/arrays/cruch_bruteforce.ts
@@ -11,7 +11,7 @@ function arrayManipulation(n: number, queries: number[][]): number {
   const result: number[] = new Array<number>(LENGTH).fill(SURROGATE_VALUE);
   let maximum = 0;
 
-  queries.forEach((query) => {
+  for (const query of queries) {
     const [aStart, bEnd, kValue] = query;
     console.debug(`start -> ${result.toString()}`);
 
@@ -19,11 +19,11 @@ function arrayManipulation(n: number, queries: number[][]): number {
       result[i] += kValue;
       console.debug(`result -> ${result.toString()}`);
     }
-  });
+  }
 
-  result.forEach((value) => {
+  for (const value of result) {
     maximum = Math.max(value, maximum);
-  });
+  }
 
   return maximum;
 }

--- a/src/hackerrank/interview_preparation_kit/arrays/cruch_optimized.test.ts
+++ b/src/hackerrank/interview_preparation_kit/arrays/cruch_optimized.test.ts
@@ -9,7 +9,7 @@ describe('arrays: crush (optimized)', () => {
   it('arrayManipulation Test Cases', () => {
     expect.assertions(4);
 
-    TEST_CASES.forEach((test) => {
+    for (const test of TEST_CASES) {
       const answer = arrayManipulation(test.n, test.queries);
 
       console.debug(
@@ -17,7 +17,7 @@ describe('arrays: crush (optimized)', () => {
       );
 
       expect(answer).toStrictEqual(test.expected);
-    });
+    }
 
     expect(TEST_CASES).toHaveLength(3);
   });

--- a/src/hackerrank/interview_preparation_kit/arrays/cruch_optimized.ts
+++ b/src/hackerrank/interview_preparation_kit/arrays/cruch_optimized.ts
@@ -11,19 +11,19 @@ function arrayManipulation(n: number, queries: number[][]): number {
   const result = new Array(LENGTH).fill(INITIAL_VALUE);
   let maximum = 0;
 
-  queries.forEach((query) => {
+  for (const query of queries) {
     const [aStart, bEnd, kValue] = query;
 
     result[aStart] += kValue;
     result[bEnd + 1] -= kValue;
-  });
+  }
 
   let accumSum = 0;
 
-  result.forEach((value) => {
+  for (const value of result) {
     accumSum += value;
     maximum = Math.max(maximum, accumSum);
-  });
+  }
 
   return maximum;
 }

--- a/src/hackerrank/interview_preparation_kit/arrays/ctci_array_left_rotation.test.ts
+++ b/src/hackerrank/interview_preparation_kit/arrays/ctci_array_left_rotation.test.ts
@@ -18,7 +18,7 @@ describe('ctci_array_left_rotation', () => {
   it('rotLeft Test cases', () => {
     expect.assertions(9);
 
-    TEST_CASES.forEach((test: RotLeftTestCase) => {
+    for (const test of TEST_CASES) {
       const answer = rotLeft(test.input, Number(test.d_rotations));
 
       console.debug(
@@ -26,7 +26,7 @@ describe('ctci_array_left_rotation', () => {
       );
 
       expect(answer).toStrictEqual(test.expected);
-    });
+    }
 
     expect(TEST_CASES).toHaveLength(8);
   });

--- a/src/hackerrank/interview_preparation_kit/arrays/minimum_swaps_2.test.ts
+++ b/src/hackerrank/interview_preparation_kit/arrays/minimum_swaps_2.test.ts
@@ -9,7 +9,7 @@ describe('minimum swaps 2', () => {
   it('minimumSwaps', () => {
     expect.assertions(4);
 
-    TEST_CASES.forEach((test) => {
+    for (const test of TEST_CASES) {
       const answer = minimumSwaps(test.input);
 
       console.debug(
@@ -17,7 +17,7 @@ describe('minimum swaps 2', () => {
       );
 
       expect(answer).toStrictEqual(test.expected);
-    });
+    }
 
     expect(TEST_CASES).toHaveLength(3);
   });

--- a/src/hackerrank/interview_preparation_kit/arrays/new_year_chaos.test.ts
+++ b/src/hackerrank/interview_preparation_kit/arrays/new_year_chaos.test.ts
@@ -9,7 +9,7 @@ describe('new_year_chaos', () => {
   it('minimumBribes Test Cases', () => {
     expect.assertions(6);
 
-    TEST_CASES.forEach((value) => {
+    for (const value of TEST_CASES) {
       const answer = minimumBribesText(value.input);
       minimumBribes(value.input);
 
@@ -18,7 +18,7 @@ describe('new_year_chaos', () => {
       );
 
       expect(answer).toStrictEqual(value.expected);
-    });
+    }
 
     expect(TEST_CASES).toHaveLength(5);
   });

--- a/src/hackerrank/interview_preparation_kit/arrays/new_year_chaos.ts
+++ b/src/hackerrank/interview_preparation_kit/arrays/new_year_chaos.ts
@@ -9,7 +9,7 @@ function minimumBribesCalculate(q: number[]): number {
   let bribes = 0;
   let i = 0;
 
-  q.forEach((value) => {
+  for (const value of q) {
     const position = i + 1;
     if (value - position > NEW_YEAR_CHAOS_TOLERANCE) {
       throw new Error(TOO_CHAOTIC_ERROR);
@@ -20,13 +20,14 @@ function minimumBribesCalculate(q: number[]): number {
       i
     );
 
-    fragment.forEach((k) => {
+    for (const k of fragment) {
       if (k > value) {
         bribes += 1;
       }
-    });
+    }
+
     i += 1;
-  });
+  }
 
   return bribes;
 }

--- a/src/hackerrank/interview_preparation_kit/dictionaries_and_hashmaps/count_triplets_1_bruteforce.test.ts
+++ b/src/hackerrank/interview_preparation_kit/dictionaries_and_hashmaps/count_triplets_1_bruteforce.test.ts
@@ -9,7 +9,7 @@ describe('count_triplets_1', () => {
   it('countTriplets test cases', () => {
     expect.assertions(5);
 
-    SMALL_TEST_CASES.forEach((test) => {
+    for (const test of SMALL_TEST_CASES) {
       const answer = CountTriplets.countTriplets(test.input, test.r);
 
       console.debug(
@@ -17,7 +17,7 @@ describe('count_triplets_1', () => {
       );
 
       expect(answer).toStrictEqual(test.expected);
-    });
+    }
 
     expect(SMALL_TEST_CASES).toHaveLength(4);
   });

--- a/src/hackerrank/interview_preparation_kit/dictionaries_and_hashmaps/count_triplets_1_optimized.test.ts
+++ b/src/hackerrank/interview_preparation_kit/dictionaries_and_hashmaps/count_triplets_1_optimized.test.ts
@@ -10,7 +10,7 @@ describe('count_triplets_1 (optimized)', () => {
   it('countTriplets small test cases', () => {
     expect.assertions(5);
 
-    SMALL_TEST_CASES.forEach((test) => {
+    for (const test of SMALL_TEST_CASES) {
       const answer = CountTriplets.countTriplets(test.input, test.r);
 
       console.debug(
@@ -18,7 +18,7 @@ describe('count_triplets_1 (optimized)', () => {
       );
 
       expect(answer).toStrictEqual(test.expected);
-    });
+    }
 
     expect(SMALL_TEST_CASES).toHaveLength(4);
   });
@@ -26,7 +26,7 @@ describe('count_triplets_1 (optimized)', () => {
   it('countTriplets big test cases', () => {
     expect.assertions(2);
 
-    BIG_TEST_CASES.forEach((test) => {
+    for (const test of BIG_TEST_CASES) {
       const answer = CountTriplets.countTriplets(test.input, test.r);
 
       console.debug(
@@ -34,7 +34,7 @@ describe('count_triplets_1 (optimized)', () => {
       );
 
       expect(answer).toStrictEqual(test.expected);
-    });
+    }
 
     expect(BIG_TEST_CASES).toHaveLength(1);
   });

--- a/src/hackerrank/interview_preparation_kit/dictionaries_and_hashmaps/count_triplets_1_optmized.ts
+++ b/src/hackerrank/interview_preparation_kit/dictionaries_and_hashmaps/count_triplets_1_optmized.ts
@@ -20,7 +20,7 @@ function countTriplets(arr: number[], ratio: number): number {
 
   const bCounter: Record<number, number> = {};
 
-  arr.forEach((x) => {
+  for (const x of arr) {
     const j = Math.floor(x / ratio);
     const k = x * ratio;
     aCounter[x] -= 1;
@@ -33,7 +33,7 @@ function countTriplets(arr: number[], ratio: number): number {
     } else {
       bCounter[x] = 1;
     }
-  });
+  }
 
   return triplets;
 }

--- a/src/hackerrank/interview_preparation_kit/dictionaries_and_hashmaps/ctci-ransom-note.test.ts
+++ b/src/hackerrank/interview_preparation_kit/dictionaries_and_hashmaps/ctci-ransom-note.test.ts
@@ -9,7 +9,7 @@ describe('ctci_ransom_note', () => {
   it('checkMagazine test cases', () => {
     expect.assertions(4);
 
-    TEST_CASES.forEach((value) => {
+    for (const value of TEST_CASES) {
       const answer = checkMagazine(value.magazine, value.note);
 
       console.debug(
@@ -17,7 +17,7 @@ describe('ctci_ransom_note', () => {
       );
 
       expect(answer).toStrictEqual(value.expected);
-    });
+    }
 
     expect(TEST_CASES).toHaveLength(3);
   });

--- a/src/hackerrank/interview_preparation_kit/dictionaries_and_hashmaps/frequency_queries_bruteforce.test.ts
+++ b/src/hackerrank/interview_preparation_kit/dictionaries_and_hashmaps/frequency_queries_bruteforce.test.ts
@@ -8,7 +8,7 @@ describe('frequency_queries_bruteforce', () => {
   it('freqQuery test cases', () => {
     expect.assertions(5);
 
-    SMALL_TEST_CASES.forEach((value) => {
+    for (const value of SMALL_TEST_CASES) {
       const answer = freqQuery(value.input);
 
       console.debug(
@@ -16,7 +16,7 @@ describe('frequency_queries_bruteforce', () => {
       );
 
       expect(answer).toStrictEqual(value.expected);
-    });
+    }
 
     expect(SMALL_TEST_CASES).toHaveLength(4);
   });

--- a/src/hackerrank/interview_preparation_kit/dictionaries_and_hashmaps/frequency_queries_bruteforce.ts
+++ b/src/hackerrank/interview_preparation_kit/dictionaries_and_hashmaps/frequency_queries_bruteforce.ts
@@ -16,7 +16,7 @@ function freqQuery(queries: number[][]): number[] {
   const __NOT_FOUND__ = 0;
   const __FOUND__ = 1;
 
-  queries.forEach((query) => {
+  for (const query of queries) {
     const [operation, data] = query;
 
     const current = dataMap?.[data] ?? __INITIAL__;
@@ -40,7 +40,7 @@ function freqQuery(queries: number[][]): number[] {
       default:
         throw new Error('Invalid operation');
     }
-  });
+  }
 
   return result;
 }

--- a/src/hackerrank/interview_preparation_kit/dictionaries_and_hashmaps/frequency_queries_optimized.test.ts
+++ b/src/hackerrank/interview_preparation_kit/dictionaries_and_hashmaps/frequency_queries_optimized.test.ts
@@ -8,7 +8,7 @@ describe('frequency_queries_optimized', () => {
   it('freqQuery test cases', () => {
     expect.assertions(5);
 
-    TEST_CASES.forEach((value) => {
+    for (const value of TEST_CASES) {
       const answer = freqQuery(value.input);
 
       console.debug(
@@ -16,7 +16,7 @@ describe('frequency_queries_optimized', () => {
       );
 
       expect(answer).toStrictEqual(value.expected);
-    });
+    }
 
     expect(TEST_CASES).toHaveLength(4);
   });

--- a/src/hackerrank/interview_preparation_kit/dictionaries_and_hashmaps/frequency_queries_optimized.ts
+++ b/src/hackerrank/interview_preparation_kit/dictionaries_and_hashmaps/frequency_queries_optimized.ts
@@ -45,7 +45,7 @@ function freqQuery(queries: number[][]): number[] {
   const __NOT_FOUND__ = 0;
   const __FOUND__ = 1;
 
-  queries.forEach((query) => {
+  for (const query of queries) {
     const [operation, data] = query;
 
     const currentFreq = dataMap?.[data] ?? __INITIAL__;
@@ -82,7 +82,7 @@ function freqQuery(queries: number[][]): number[] {
     if (operation === __INSERT__ || operation === __DELETE__) {
       updateFrequency(freqMap, data, currentFreq, newFreq);
     }
-  });
+  }
 
   return result;
 }

--- a/src/hackerrank/interview_preparation_kit/dictionaries_and_hashmaps/sherlock_and_anagrams.test.ts
+++ b/src/hackerrank/interview_preparation_kit/dictionaries_and_hashmaps/sherlock_and_anagrams.test.ts
@@ -10,8 +10,8 @@ describe('sherlock_and_anagrams', () => {
 
     let totalTestsCount = 0;
 
-    TEST_CASES.forEach((testSet) => {
-      testSet?.tests.forEach((test) => {
+    for (const testSet of TEST_CASES) {
+      for (const test of testSet.tests) {
         const answer = sherlockAndAnagrams(test.input);
 
         console.debug(
@@ -21,8 +21,8 @@ describe('sherlock_and_anagrams', () => {
         expect(answer).toStrictEqual(test.expected);
 
         totalTestsCount += 1;
-      });
-    });
+      }
+    }
 
     expect(TEST_CASES).toHaveLength(4);
     expect(totalTestsCount).toBe(15);

--- a/src/hackerrank/interview_preparation_kit/dictionaries_and_hashmaps/two_strings.test.ts
+++ b/src/hackerrank/interview_preparation_kit/dictionaries_and_hashmaps/two_strings.test.ts
@@ -11,8 +11,8 @@ describe('two_strings', () => {
 
     let totalTestsCount = 0;
 
-    TEST_CASES.forEach((testCase) => {
-      testCase?.test.forEach((test) => {
+    for (const testCase of TEST_CASES) {
+      for (const test of testCase.test) {
         const answer = twoStrings(test.s1, test.s2);
 
         console.debug(
@@ -22,8 +22,8 @@ describe('two_strings', () => {
         expect(answer).toStrictEqual(test.expected);
 
         totalTestsCount += 1;
-      });
-    });
+      }
+    }
 
     expect(TEST_CASES).toHaveLength(3);
     expect(totalTestsCount).toBe(8);

--- a/src/hackerrank/interview_preparation_kit/dynamic_programming/max_array_sum.test.ts
+++ b/src/hackerrank/interview_preparation_kit/dynamic_programming/max_array_sum.test.ts
@@ -14,7 +14,7 @@ describe('max_array_sum', () => {
   it('maxSubsetSum test cases', () => {
     expect.assertions(5);
 
-    ALL_TEST_CASES.forEach((test) => {
+    for (const test of ALL_TEST_CASES) {
       const answer = maxSubsetSum(test.input).toString(DECIMAL_RADIX);
 
       console.debug(
@@ -22,7 +22,7 @@ describe('max_array_sum', () => {
       );
 
       expect(answer).toStrictEqual(test.expected);
-    });
+    }
 
     expect(ALL_TEST_CASES).toHaveLength(4);
   });

--- a/src/hackerrank/interview_preparation_kit/greedy_algorithms/angry_children.test.ts
+++ b/src/hackerrank/interview_preparation_kit/greedy_algorithms/angry_children.test.ts
@@ -9,7 +9,7 @@ describe('angry_children', () => {
   it('maxMin test cases', () => {
     expect.assertions(5);
 
-    TEST_CASES.forEach((test) => {
+    for (const test of TEST_CASES) {
       const answer = maxMin(test.k, test.arr);
 
       console.debug(
@@ -17,7 +17,7 @@ describe('angry_children', () => {
       );
 
       expect(answer).toStrictEqual(test.expected);
-    });
+    }
 
     expect(TEST_CASES).toHaveLength(4);
   });

--- a/src/hackerrank/interview_preparation_kit/greedy_algorithms/greedy_florist.test.ts
+++ b/src/hackerrank/interview_preparation_kit/greedy_algorithms/greedy_florist.test.ts
@@ -9,7 +9,7 @@ describe('greedy_florist', () => {
   it('greedy_florist test cases', () => {
     expect.assertions(4);
 
-    TEST_CASES.forEach((test) => {
+    for (const test of TEST_CASES) {
       const answer = getMinimumCost(test.k, test.contests);
 
       console.debug(
@@ -17,7 +17,7 @@ describe('greedy_florist', () => {
       );
 
       expect(answer).toStrictEqual(test.expected);
-    });
+    }
 
     expect(TEST_CASES).toHaveLength(3);
   });

--- a/src/hackerrank/interview_preparation_kit/greedy_algorithms/greedy_florist.ts
+++ b/src/hackerrank/interview_preparation_kit/greedy_algorithms/greedy_florist.ts
@@ -11,12 +11,12 @@ function getMinimumCost(k: number, c: number[]): number {
   let total = 0;
 
   let i = 0;
-  flowers.forEach((flowerCost) => {
+  for (const flowerCost of flowers) {
     const position = Math.floor(i / k);
 
     total += (position + 1) * flowerCost;
     i += 1;
-  });
+  }
 
   return total;
 }

--- a/src/hackerrank/interview_preparation_kit/greedy_algorithms/luck-balance.test.ts
+++ b/src/hackerrank/interview_preparation_kit/greedy_algorithms/luck-balance.test.ts
@@ -9,7 +9,7 @@ describe('luck-balance', () => {
   it('luckBalance test cases', () => {
     expect.assertions(4);
 
-    TEST_CASES.forEach((test) => {
+    for (const test of TEST_CASES) {
       const answer = luckBalance.luckBalance(test.k, test.contests);
 
       console.debug(
@@ -17,7 +17,7 @@ describe('luck-balance', () => {
       );
 
       expect(answer).toStrictEqual(test.expected);
-    });
+    }
 
     expect(TEST_CASES).toHaveLength(3);
   });

--- a/src/hackerrank/interview_preparation_kit/greedy_algorithms/luck-balance.ts
+++ b/src/hackerrank/interview_preparation_kit/greedy_algorithms/luck-balance.ts
@@ -46,7 +46,7 @@ function luckBalance(k: number, contests: number[][]): number {
   let importantContests: Contest[] = [];
   const nonimportantContests: Contest[] = [];
 
-  contests.forEach((contest) => {
+  for (const contest of contests) {
     const [luck, important] = [...contest];
     const theContest = new Contest(luck, important);
 
@@ -55,7 +55,7 @@ function luckBalance(k: number, contests: number[][]): number {
     } else {
       nonimportantContests.push(theContest);
     }
-  });
+  }
 
   importantContests = dynamicSort(importantContests, [
     { property: 'important', order: 'desc' },
@@ -74,9 +74,9 @@ function luckBalance(k: number, contests: number[][]): number {
     total -= importantContests[i].luck;
   }
 
-  nonimportantContests.forEach((contest) => {
+  for (const contest of nonimportantContests) {
     total += contest.luck;
-  });
+  }
 
   return total;
 }

--- a/src/hackerrank/interview_preparation_kit/greedy_algorithms/minimum_absolute_difference_in_an_array.test.ts
+++ b/src/hackerrank/interview_preparation_kit/greedy_algorithms/minimum_absolute_difference_in_an_array.test.ts
@@ -9,7 +9,7 @@ describe('minimum_absolute_difference_in_an_array', () => {
   it('minimumAbsoluteDifference test cases', () => {
     expect.assertions(4);
 
-    TEST_CASES.forEach((test) => {
+    for (const test of TEST_CASES) {
       const answer = minimumAbsoluteDifference(test.input);
 
       console.debug(
@@ -17,7 +17,7 @@ describe('minimum_absolute_difference_in_an_array', () => {
       );
 
       expect(answer).toStrictEqual(test.expected);
-    });
+    }
 
     expect(TEST_CASES).toHaveLength(3);
   });

--- a/src/hackerrank/interview_preparation_kit/miscellaneous/flipping-bits-alt.test.ts
+++ b/src/hackerrank/interview_preparation_kit/miscellaneous/flipping-bits-alt.test.ts
@@ -11,8 +11,8 @@ describe('flipping bits', () => {
 
     let totalTestsCount = 0;
 
-    TEST_CASES.forEach((testSet) => {
-      testSet.tests.forEach((test) => {
+    for (const testSet of TEST_CASES) {
+      for (const test of testSet.tests) {
         const answer = flippingBitsAlt(test.input);
 
         console.debug(
@@ -22,8 +22,8 @@ describe('flipping bits', () => {
         expect(answer).toStrictEqual(test.expected);
 
         totalTestsCount += 1;
-      });
-    });
+      }
+    }
 
     expect(TEST_CASES).toHaveLength(3);
     expect(totalTestsCount).toBe(8);

--- a/src/hackerrank/interview_preparation_kit/miscellaneous/flipping-bits.test.ts
+++ b/src/hackerrank/interview_preparation_kit/miscellaneous/flipping-bits.test.ts
@@ -11,8 +11,8 @@ describe('flipping bits', () => {
 
     let totalTestsCount = 0;
 
-    TEST_CASES.forEach((testSet) => {
-      testSet.tests.forEach((test) => {
+    for (const testSet of TEST_CASES) {
+      for (const test of testSet.tests) {
         const answer = flippingBits(test.input);
 
         console.debug(`flippingBits(${test.input}) solution found: ${answer}`);
@@ -20,8 +20,8 @@ describe('flipping bits', () => {
         expect(answer).toStrictEqual(test.expected);
 
         totalTestsCount += 1;
-      });
-    });
+      }
+    }
 
     expect(TEST_CASES).toHaveLength(3);
     expect(totalTestsCount).toBe(8);

--- a/src/hackerrank/interview_preparation_kit/miscellaneous/flipping-bits.ts
+++ b/src/hackerrank/interview_preparation_kit/miscellaneous/flipping-bits.ts
@@ -11,13 +11,13 @@ function flippingBits(n: number): number {
 
   let resultBinStr = '';
 
-  nBinaryStr.split('').forEach((binDigit) => {
+  for (const binDigit of nBinaryStr.split('')) {
     if (binDigit === '1') {
       resultBinStr += '0';
     } else {
       resultBinStr += '1';
     }
-  });
+  }
 
   return Number.parseInt(resultBinStr, __BINARY_BASE__);
 }

--- a/src/hackerrank/interview_preparation_kit/miscellaneous/friend_circle_queries.test.ts
+++ b/src/hackerrank/interview_preparation_kit/miscellaneous/friend_circle_queries.test.ts
@@ -8,7 +8,7 @@ describe('friend_circle_queries', () => {
   it('maxCircle test cases', () => {
     expect.assertions(5);
 
-    TEST_CASES.forEach((test) => {
+    for (const test of TEST_CASES) {
       const answer = maxCircle(test.arr);
 
       console.debug(
@@ -16,7 +16,7 @@ describe('friend_circle_queries', () => {
       );
 
       expect(answer).toStrictEqual(test.expected);
-    });
+    }
 
     expect(TEST_CASES).toHaveLength(4);
   });

--- a/src/hackerrank/interview_preparation_kit/miscellaneous/friend_circle_queries.ts
+++ b/src/hackerrank/interview_preparation_kit/miscellaneous/friend_circle_queries.ts
@@ -60,13 +60,13 @@ function maxCircle(queries: number[][]): number[] {
   const result: number[] = [];
   const friends = new GropingFriends();
 
-  queries.forEach((query) => {
+  for (const query of queries) {
     // Computing friendship
     friends.unite(query[0], query[1]);
 
     // Counting friends groups
     result.push(friends.count_groups());
-  });
+  }
 
   return result;
 }

--- a/src/hackerrank/interview_preparation_kit/recursion_and_backtracking/ctci_fibonacci_numbers.test.ts
+++ b/src/hackerrank/interview_preparation_kit/recursion_and_backtracking/ctci_fibonacci_numbers.test.ts
@@ -8,13 +8,13 @@ describe('ctci_fibonacci_numbers', () => {
   it('fibonacci test cases', () => {
     expect.assertions(4);
 
-    TEST_CASES.forEach((test) => {
+    for (const test of TEST_CASES) {
       const answer = fibonacci(test.input);
 
       console.debug(`fibonacci(${test.input}) solution found: ${answer}`);
 
       expect(answer).toStrictEqual(test.expected);
-    });
+    }
 
     expect(TEST_CASES).toHaveLength(3);
   });

--- a/src/hackerrank/interview_preparation_kit/recursion_and_backtracking/ctci_recursive_staircase.test.ts
+++ b/src/hackerrank/interview_preparation_kit/recursion_and_backtracking/ctci_recursive_staircase.test.ts
@@ -9,15 +9,15 @@ describe('ctci_recursive_staircase', () => {
   it('stepPerms test cases', () => {
     expect.assertions(9);
 
-    TEST_CASES.forEach((testSet) => {
-      testSet?.tests.forEach((test) => {
+    for (const testSet of TEST_CASES) {
+      for (const test of testSet.tests) {
         const answer = stepPerms(test.n_steps);
 
         console.debug(`stepPerms(${test.n_steps}) solution found: ${answer}`);
 
         expect(answer).toStrictEqual(test.expected);
-      });
-    });
+      }
+    }
 
     expect(TEST_CASES).toHaveLength(3);
   });
@@ -27,8 +27,8 @@ describe('ctci_recursive_staircase', () => {
 
     const TOP_LIMIT = 10 ** 10 + 7;
 
-    TEST_CASES_GENERALIZED.forEach((testSet) => {
-      testSet?.tests.forEach((test) => {
+    for (const testSet of TEST_CASES_GENERALIZED) {
+      for (const test of testSet.tests) {
         const stairs = new StepPerms(TOP_LIMIT, test.steps_limit);
 
         const answer = stairs.step_perms_comput_with_cache(test.n_steps);
@@ -38,8 +38,8 @@ describe('ctci_recursive_staircase', () => {
         );
 
         expect(answer).toStrictEqual(test.expected);
-      });
-    });
+      }
+    }
 
     expect(TEST_CASES_GENERALIZED).toHaveLength(3);
   });

--- a/src/hackerrank/interview_preparation_kit/recursion_and_backtracking/recursive_digit_sum.bruteforce-test.ts
+++ b/src/hackerrank/interview_preparation_kit/recursion_and_backtracking/recursive_digit_sum.bruteforce-test.ts
@@ -8,13 +8,13 @@ describe('recursive_digit_sum bruteforce', () => {
   it('superDigit test cases', () => {
     expect.assertions(4);
 
-    TEST_CASES.forEach((test) => {
+    for (const test of TEST_CASES) {
       const answer = superDigit(test.n, test.k);
 
       console.debug(`superDigit(${test.n}) solution found: ${answer}`);
 
       expect(answer).toStrictEqual(test.expected);
-    });
+    }
 
     expect(TEST_CASES).toHaveLength(3);
   });

--- a/src/hackerrank/interview_preparation_kit/recursion_and_backtracking/recursive_digit_sum.test.ts
+++ b/src/hackerrank/interview_preparation_kit/recursion_and_backtracking/recursive_digit_sum.test.ts
@@ -8,13 +8,13 @@ describe('recursive_digit_sum', () => {
   it('superDigit test cases', () => {
     expect.assertions(5);
 
-    TEST_CASES.forEach((test) => {
+    for (const test of TEST_CASES) {
       const answer = superDigit(test.n, test.k);
 
       console.debug(`superDigit(${test.n}) solution found: ${answer}`);
 
       expect(answer).toStrictEqual(test.expected);
-    });
+    }
 
     expect(TEST_CASES).toHaveLength(4);
   });

--- a/src/hackerrank/interview_preparation_kit/search/ctci_ice_cream_parlor.test.ts
+++ b/src/hackerrank/interview_preparation_kit/search/ctci_ice_cream_parlor.test.ts
@@ -11,8 +11,8 @@ describe('ctci_ice_cream_parlor', () => {
 
     let totalTestsCount = 0;
 
-    TEST_CASES.forEach((testSet) => {
-      testSet?.tests.forEach((test) => {
+    for (const testSet of TEST_CASES) {
+      for (const test of testSet.tests) {
         const answer = whatFlavorsCompute(test.costs, test.money);
 
         console.debug(
@@ -23,8 +23,8 @@ describe('ctci_ice_cream_parlor', () => {
         expect(whatFlavors(test.costs, test.money)).toBeUndefined();
 
         totalTestsCount += 1;
-      });
-    });
+      }
+    }
 
     expect(TEST_CASES).toHaveLength(3);
     expect(totalTestsCount).toBe(5);
@@ -35,16 +35,16 @@ describe('ctci_ice_cream_parlor', () => {
 
     let totalTestsCount = 0;
 
-    TEST_CASES_BORDER_CASES.forEach((testSet) => {
-      testSet?.tests.forEach((test) => {
+    for (const testSet of TEST_CASES_BORDER_CASES) {
+      for (const test of testSet.tests) {
         expect(whatFlavorsCompute(test.costs, test.money)).toStrictEqual(
           test.expected
         );
         expect(whatFlavors(test.costs, test.money)).toBeUndefined();
 
         totalTestsCount += 1;
-      });
-    });
+      }
+    }
 
     expect(TEST_CASES_BORDER_CASES).toHaveLength(1);
     expect(totalTestsCount).toBe(1);

--- a/src/hackerrank/interview_preparation_kit/search/ctci_ice_cream_parlor_bruteforce.test.ts
+++ b/src/hackerrank/interview_preparation_kit/search/ctci_ice_cream_parlor_bruteforce.test.ts
@@ -14,8 +14,8 @@ describe('ctci_ice_cream_parlor_bruteforce', () => {
 
     let totalTestsCount = 0;
 
-    TEST_CASES.forEach((testSet) => {
-      testSet?.tests.forEach((test) => {
+    for (const testSet of TEST_CASES) {
+      for (const test of testSet.tests) {
         const answer = whatFlavorsBruteforceCompute(test.costs, test.money);
 
         console.debug(
@@ -26,8 +26,8 @@ describe('ctci_ice_cream_parlor_bruteforce', () => {
         expect(whatFlavors(test.costs, test.money)).toBeUndefined();
 
         totalTestsCount += 1;
-      });
-    });
+      }
+    }
 
     expect(TEST_CASES).toHaveLength(3);
     expect(totalTestsCount).toBe(5);
@@ -38,16 +38,16 @@ describe('ctci_ice_cream_parlor_bruteforce', () => {
 
     let totalTestsCount = 0;
 
-    TEST_CASES_BORDER_CASES.forEach((testSet) => {
-      testSet?.tests.forEach((test) => {
+    for (const testSet of TEST_CASES_BORDER_CASES) {
+      for (const test of testSet.tests) {
         expect(
           whatFlavorsBruteforceCompute(test.costs, test.money)
         ).toStrictEqual(test.expected);
         expect(whatFlavors(test.costs, test.money)).toBeUndefined();
 
         totalTestsCount += 1;
-      });
-    });
+      }
+    }
 
     expect(TEST_CASES_BORDER_CASES).toHaveLength(1);
     expect(totalTestsCount).toBe(1);

--- a/src/hackerrank/interview_preparation_kit/search/ctci_ice_cream_parlor_optimized.test.ts
+++ b/src/hackerrank/interview_preparation_kit/search/ctci_ice_cream_parlor_optimized.test.ts
@@ -14,8 +14,8 @@ describe('ctci_ice_cream_parlor_optimized', () => {
 
     let totalTestsCount = 0;
 
-    TEST_CASES.forEach((testSet) => {
-      testSet?.tests.forEach((test) => {
+    for (const testSet of TEST_CASES) {
+      for (const test of testSet.tests) {
         const answer = whatFlavorsCompute(test.costs, test.money);
 
         console.debug(
@@ -26,8 +26,8 @@ describe('ctci_ice_cream_parlor_optimized', () => {
         expect(whatFlavors(test.costs, test.money)).toBeUndefined();
 
         totalTestsCount += 1;
-      });
-    });
+      }
+    }
 
     expect(TEST_CASES).toHaveLength(3);
     expect(totalTestsCount).toBe(5);
@@ -38,16 +38,16 @@ describe('ctci_ice_cream_parlor_optimized', () => {
 
     let totalTestsCount = 0;
 
-    TEST_CASES_BORDER_CASES.forEach((testSet) => {
-      testSet?.tests.forEach((test) => {
+    for (const testSet of TEST_CASES_BORDER_CASES) {
+      for (const test of testSet.tests) {
         expect(whatFlavorsCompute(test.costs, test.money)).toStrictEqual(
           test.expected
         );
         expect(whatFlavors(test.costs, test.money)).toBeUndefined();
 
         totalTestsCount += 1;
-      });
-    });
+      }
+    }
 
     expect(TEST_CASES_BORDER_CASES).toHaveLength(1);
     expect(totalTestsCount).toBe(1);

--- a/src/hackerrank/interview_preparation_kit/search/swap_nodes_algo.big.test.ts
+++ b/src/hackerrank/interview_preparation_kit/search/swap_nodes_algo.big.test.ts
@@ -7,12 +7,12 @@ describe('swap_nodes_algo', () => {
   it('buildTree and plain test cases', () => {
     expect.assertions(2);
 
-    BIG_TEST_CASES.forEach((test) => {
+    for (const test of BIG_TEST_CASES) {
       const tree: Tree = new Tree(test.nodes);
       const tresult: number[] = tree.flatTree();
 
       expect(tresult).toStrictEqual(test.flattened);
-    });
+    }
 
     expect(BIG_TEST_CASES).toHaveLength(1);
   });
@@ -20,11 +20,11 @@ describe('swap_nodes_algo', () => {
   it('swapNodes test cases', () => {
     expect.assertions(2);
 
-    BIG_TEST_CASES.forEach((test) => {
+    for (const test of BIG_TEST_CASES) {
       const tResult = swapNodes(test.nodes, test.queries);
 
       expect(tResult).toStrictEqual(test.expected);
-    });
+    }
 
     expect(BIG_TEST_CASES).toHaveLength(1);
   });

--- a/src/hackerrank/interview_preparation_kit/search/swap_nodes_algo.test.ts
+++ b/src/hackerrank/interview_preparation_kit/search/swap_nodes_algo.test.ts
@@ -35,12 +35,12 @@ describe('swap_nodes_algo', () => {
   it('build tree and flattened tree test cases', () => {
     expect.assertions(5);
 
-    TEST_CASES.forEach((test) => {
+    for (const test of TEST_CASES) {
       const tree = new Tree(test.nodes);
       const tResult = tree.flatTree();
 
       expect(tResult).toStrictEqual(test.flattened);
-    });
+    }
 
     expect(TEST_CASES).toHaveLength(4);
   });
@@ -48,11 +48,11 @@ describe('swap_nodes_algo', () => {
   it('swapNodes test cases', () => {
     expect.assertions(5);
 
-    TEST_CASES.forEach((test) => {
+    for (const test of TEST_CASES) {
       const tResult: number[][] = swapNodes(test.nodes, test.queries);
 
       expect(tResult).toStrictEqual(test.expected);
-    });
+    }
 
     expect(TEST_CASES).toHaveLength(4);
   });

--- a/src/hackerrank/interview_preparation_kit/search/swap_nodes_algo.ts
+++ b/src/hackerrank/interview_preparation_kit/search/swap_nodes_algo.ts
@@ -89,9 +89,10 @@ class Tree {
     traverseInOrderFlat(this.root);
 
     const output: number[] = [];
-    flatTreeCollector.forEach((node) => {
+
+    for (const node of flatTreeCollector) {
       output.push(node.data);
-    });
+    }
 
     return output;
   }

--- a/src/hackerrank/interview_preparation_kit/sort/ctci_bubble_sort.test.ts
+++ b/src/hackerrank/interview_preparation_kit/sort/ctci_bubble_sort.test.ts
@@ -7,14 +7,14 @@ describe('countSwaps', () => {
   it('build tree and flattened tree test cases', () => {
     expect.assertions(7);
 
-    TEST_CASES.forEach((test) => {
+    for (const test of TEST_CASES) {
       const sortable = new SortableGroup(test.input);
       const resultSort = sortable.bubble_sort().group;
       const resultPrint = countSwaps(test.input);
 
       expect(resultPrint).toBeUndefined();
       expect(resultSort).toStrictEqual(test.sorted);
-    });
+    }
 
     expect(TEST_CASES).toHaveLength(3);
   });

--- a/src/hackerrank/interview_preparation_kit/sort/ctci_comparator_sorting.test.ts
+++ b/src/hackerrank/interview_preparation_kit/sort/ctci_comparator_sorting.test.ts
@@ -26,7 +26,7 @@ describe('comparatorSorting', () => {
   it('test_comparator_sorting', () => {
     expect.assertions(9);
 
-    TEST_CASES.forEach((test) => {
+    for (const test of TEST_CASES) {
       const players: SortablePlayer[] = [];
 
       for (const player of test.input) {
@@ -35,7 +35,7 @@ describe('comparatorSorting', () => {
 
       expect(comparatorSorting(players)).toStrictEqual(test.sorted);
       expect(comparatorSortingPrint(players)).toBeUndefined();
-    });
+    }
 
     expect(TEST_CASES).toHaveLength(4);
   });

--- a/src/hackerrank/interview_preparation_kit/sort/mark_and_toys.test.ts
+++ b/src/hackerrank/interview_preparation_kit/sort/mark_and_toys.test.ts
@@ -7,11 +7,11 @@ describe('maximumToys', () => {
   it('maximumToys test cases', () => {
     expect.assertions(4);
 
-    TEST_CASES.forEach((test) => {
+    for (const test of TEST_CASES) {
       const result = maximumToys(test.prices, test.budget);
 
       expect(result).toStrictEqual(test.expected);
-    });
+    }
 
     expect(TEST_CASES).toHaveLength(3);
   });

--- a/src/hackerrank/interview_preparation_kit/stacks_and_queues/balanced_brackets.test.ts
+++ b/src/hackerrank/interview_preparation_kit/stacks_and_queues/balanced_brackets.test.ts
@@ -11,15 +11,15 @@ describe('isBalanced', () => {
 
     let totalTestsCount = 0;
 
-    TEST_CASES.forEach((testSet) => {
-      testSet?.tests.forEach((test) => {
+    for (const testSet of TEST_CASES) {
+      for (const test of testSet.tests) {
         const result = isBalanced(test.input) === __YES__;
 
         expect(result).toStrictEqual(test.expected);
 
         totalTestsCount += 1;
-      });
-    });
+      }
+    }
 
     expect(TEST_CASES).toHaveLength(3);
     expect(totalTestsCount).toBe(8);

--- a/src/hackerrank/interview_preparation_kit/string_manipulation/alternating_characters.test.ts
+++ b/src/hackerrank/interview_preparation_kit/string_manipulation/alternating_characters.test.ts
@@ -9,15 +9,15 @@ describe('alternatingCharacters', () => {
 
     let totalTestsCount = 0;
 
-    TEST_CASES.forEach((testSet) => {
-      testSet?.tests.forEach((test) => {
+    for (const testSet of TEST_CASES) {
+      for (const test of testSet.tests) {
         const result = alternatingCharacters(test.input);
 
         expect(result).toStrictEqual(test.expected);
 
         totalTestsCount += 1;
-      });
-    });
+      }
+    }
 
     expect(TEST_CASES).toHaveLength(3);
     expect(totalTestsCount).toBe(9);

--- a/src/hackerrank/interview_preparation_kit/string_manipulation/ctci_making_anagrams.test.ts
+++ b/src/hackerrank/interview_preparation_kit/string_manipulation/ctci_making_anagrams.test.ts
@@ -7,11 +7,11 @@ describe('makeAnagram', () => {
   it('makeAnagram test cases', () => {
     expect.assertions(4);
 
-    TEST_CASES.forEach((test) => {
+    for (const test of TEST_CASES) {
       const result = makeAnagram(test.a, test.b);
 
       expect(result).toStrictEqual(test.expected);
-    });
+    }
 
     expect(TEST_CASES).toHaveLength(3);
   });

--- a/src/hackerrank/interview_preparation_kit/string_manipulation/sherlock_and_valid_string.test.ts
+++ b/src/hackerrank/interview_preparation_kit/string_manipulation/sherlock_and_valid_string.test.ts
@@ -9,11 +9,11 @@ describe('isValid', () => {
 
     const __YES__ = 'YES';
 
-    TEST_CASES.forEach((test) => {
+    for (const test of TEST_CASES) {
       const result = isValid(test.input) === __YES__;
 
       expect(result).toStrictEqual(test.expected);
-    });
+    }
 
     expect(TEST_CASES).toHaveLength(9);
   });

--- a/src/hackerrank/projecteuler/euler001.test.ts
+++ b/src/hackerrank/projecteuler/euler001.test.ts
@@ -9,14 +9,14 @@ describe('euler001', () => {
   it('euler001 Test case 0', () => {
     expect.assertions(4);
 
-    TEST_CASES.forEach((test) => {
+    for (const test of TEST_CASES) {
       const calculated = euler001(test.a, test.b, test.n);
       console.log(
         `euler001(${test.a}, ${test.b}, ${test.n}) solution found: ${test.answer}`
       );
 
       expect(calculated).toStrictEqual(test.answer);
-    });
+    }
 
     expect(TEST_CASES).toHaveLength(3);
   });

--- a/src/hackerrank/projecteuler/euler002.test.ts
+++ b/src/hackerrank/projecteuler/euler002.test.ts
@@ -9,12 +9,12 @@ describe('euler002', () => {
   it('euler002 JSON Test cases', () => {
     expect.assertions(3);
 
-    TEST_CASES.forEach((test) => {
+    for (const test of TEST_CASES) {
       const calculated = euler002(test.n);
       console.log(`euler002(${test.n}) solution found: ${test.expected}`);
 
       expect(`${calculated}`).toBe(`${test.expected}`);
-    });
+    }
 
     expect(TEST_CASES).toHaveLength(2);
   });

--- a/src/hackerrank/projecteuler/euler003.test.ts
+++ b/src/hackerrank/projecteuler/euler003.test.ts
@@ -9,12 +9,12 @@ describe('euler003', () => {
   it('euler003 JSON Test cases', () => {
     expect.assertions(3);
 
-    TEST_CASES.forEach((test) => {
+    for (const test of TEST_CASES) {
       const calculated = euler003(test.n);
       console.log(`euler003(${test.n}) solution found: ${test.expected}`);
 
       expect(`${calculated}`).toBe(`${test.expected}`);
-    });
+    }
 
     expect(TEST_CASES).toHaveLength(2);
   });

--- a/src/hackerrank/warmup/plusMinus.ts
+++ b/src/hackerrank/warmup/plusMinus.ts
@@ -17,11 +17,11 @@ function plusMinus(arr: number[]): string {
     }
   }
 
-  const result: string[] = [];
-
-  result.push((positives / arr.length).toFixed(6));
-  result.push((negatives / arr.length).toFixed(6));
-  result.push((zeros / arr.length).toFixed(6));
+  const result: string[] = [
+    (positives / arr.length).toFixed(6),
+    (negatives / arr.length).toFixed(6),
+    (zeros / arr.length).toFixed(6)
+  ];
 
   return result.join(`\n`);
 }

--- a/src/hackerrank/warmup/solveMeFirst.ts
+++ b/src/hackerrank/warmup/solveMeFirst.ts
@@ -7,9 +7,9 @@ const __RADIX__ = 10;
 function solveMeFirst(inputLines: string[]): number {
   let result = 0;
 
-  inputLines.forEach((v) => {
+  for (const v of inputLines) {
     result += Number.parseInt(v, __RADIX__);
-  });
+  }
 
   return result;
 }

--- a/src/projecteuler/helpers/bigNumbers.ts
+++ b/src/projecteuler/helpers/bigNumbers.ts
@@ -3,7 +3,7 @@ export const bigNum = (strNumber: string, base = 10): number[] => {
   let i;
 
   for (i = 0; i < strNumber.length; i++) {
-    result.push(parseInt(strNumber.charAt(i), base));
+    result.push(Number.parseInt(strNumber.charAt(i), base));
   }
 
   return result;

--- a/src/projecteuler/problem0005.ts
+++ b/src/projecteuler/problem0005.ts
@@ -44,9 +44,9 @@ function _replaceMaximum(
 function _primeFactorsCollection(_factors: number[]): Map<number, number> {
   let collection = new Map<number, number>();
 
-  _factors.forEach((factor) => {
+  for (const factor of _factors) {
     collection = _increase(factor, collection);
-  });
+  }
 
   return collection;
 }

--- a/src/projecteuler/problem0013-alt.ts
+++ b/src/projecteuler/problem0013-alt.ts
@@ -12,9 +12,9 @@ function problem0013alt(
 
   let sum = BigInt(0);
 
-  arrayOfNumbers.forEach((num: string) => {
+  for (const num of arrayOfNumbers) {
     sum += BigInt(num);
-  });
+  }
 
   console.debug(`Sum: ${sum}`);
 

--- a/src/projecteuler/problem0016-alt.ts
+++ b/src/projecteuler/problem0016-alt.ts
@@ -34,9 +34,9 @@ function problem0016alt(base: string, exponent: number): string {
   const digits = strPower.split('');
 
   let result = 0;
-  digits.forEach((num: string) => {
+  for (const num of digits) {
     result += Number.parseInt(num, __RADIX__);
-  });
+  }
 
   console.log(`Sum of Digits: (${result})`);
 

--- a/src/projecteuler/problem0021.ts
+++ b/src/projecteuler/problem0021.ts
@@ -28,7 +28,9 @@ function problem0021(_start: number, _limit: number): string {
 
   const amicableNumbers: string[] = [];
 
-  Object.entries(properDivisorsOf).forEach((value, index) => {
+  for (const [key, value] of Object.entries(properDivisorsOf)) {
+    const index = Number.parseInt(key, 10);
+
     if (
       value &&
       properDivisorsOf[index] &&
@@ -38,7 +40,7 @@ function problem0021(_start: number, _limit: number): string {
     ) {
       amicableNumbers.push(`${index}`);
     }
-  });
+  }
 
   console.log(`result: ${properDivisorsOf.toString()}`);
   console.log(`amicableNumbers: ${amicableNumbers.toString()}`);


### PR DESCRIPTION
Number static methods and properties should be preferred over global equivalents typescript:S7773